### PR TITLE
Add tests for all telosbookdex ballots

### DIFF
--- a/include/vapaee/base/base.hpp
+++ b/include/vapaee/base/base.hpp
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 
 #include <tuple>
+#include <algorithm>
 
 // defining namespaces 
 using namespace eosio;

--- a/include/vapaee/dex/modules/dao.hpp
+++ b/include/vapaee/dex/modules/dao.hpp
@@ -209,24 +209,23 @@ namespace vapaee {
 
                 PRINT(" str: ", str.c_str(), "\n");
                 
-                auto i = str.find(" ");
+                int i = str.find(" ");
                 
                 string param1 = str.substr(0, i);
-                string param2 = str.substr(i+1);
+                string param2 = str.substr(i + 1);
                 
                 PRINT(" -> i: ", std::to_string((int)i), "\n");
                 PRINT(" -> param1: ", param1.c_str(), "\n");
                 PRINT(" -> param2: ", param2.c_str(), "\n");
                 
-                float value = aux_check_float_from_string(param1);
                 symbol_code sym_code = aux_check_symbol_code_from_string(param2);
 
-                // deduce precision
-                uint8_t pt = (uint8_t) param1.find(".");
-                uint8_t size = (uint8_t) param1.size();
-                uint8_t precision = size-1-pt;
-                uint64_t multiplier = pow(10, precision);
-                uint64_t amount = value * multiplier;
+                int dot_index = param1.find('.');
+                uint8_t precision = param1.length() - (dot_index + 1);
+
+                param1.erase(std::remove(param1.begin(), param1.end(), '.'), param1.end());
+
+                uint64_t amount = std::atoi(param1.c_str()); 
 
                 PRINT(" -> precision: ", std::to_string(precision), "\n");
                 PRINT(" -> amount: ", std::to_string((unsigned long long) amount), "\n");

--- a/tests/telosbookdex/ballots/test_approvalmin.py
+++ b/tests/telosbookdex/ballots/test_approvalmin.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+from pytest_eosiocdt import name_to_string
+from pytest_eosiocdt.telos import telosdecide
+
+from ..constants import telosbookdex
+
+
+def test_ballot_on_approvalmin_yes(telosdecide, telosbookdex):
+
+    new_min = .5
+
+    with telosbookdex.perform_vote(
+        telosdecide,
+        [['yes']]
+    ) as vote_info:
+        voters, ballot_acc  = vote_info 
+        ec, out = telosbookdex.dao_approvalmin(
+            new_min,
+            ballot_acc
+        )
+
+        assert ec == 0
+
+    ballot_info = telosbookdex.get_ballot_by_feepayer(ballot_acc) 
+
+    assert ballot_info is not None
+    assert ballot_info['approved'] == 1
+    assert ballot_info['accepted'] == 1
+
+    config = telosbookdex.get_config()
+
+    assert float(config['approvalmin']) == new_min
+
+
+def test_ballot_on_approvalmin_no(telosdecide, telosbookdex):
+
+    old_min = float(telosbookdex.get_config()['approvalmin'])
+    new_min = .5
+
+    with telosbookdex.perform_vote(
+        telosdecide,
+        [['no']]
+    ) as vote_info:
+        voters, ballot_acc  = vote_info 
+        ec, out = telosbookdex.dao_approvalmin(
+            new_min,
+            ballot_acc
+        )
+
+        assert ec == 0
+
+    ballot_info = telosbookdex.get_ballot_by_feepayer(ballot_acc) 
+
+    assert ballot_info is not None
+    assert ballot_info['approved'] == 0
+    assert ballot_info['accepted'] == 1
+
+    config = telosbookdex.get_config()
+
+    assert float(config['approvalmin']) == old_min

--- a/tests/telosbookdex/ballots/test_ballotsprune.py
+++ b/tests/telosbookdex/ballots/test_ballotsprune.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+from pytest_eosiocdt import name_to_string
+from pytest_eosiocdt.telos import telosdecide
+
+from ..constants import telosbookdex
+
+
+def test_ballot_on_ballotsprune_yes(telosdecide, telosbookdex):
+
+    max_entries = 500
+
+    with telosbookdex.perform_vote(
+        telosdecide,
+        [['yes']]
+    ) as vote_info:
+        voters, ballot_acc  = vote_info 
+        ec, out = telosbookdex.dao_ballotsprune(
+            max_entries,
+            ballot_acc
+        )
+
+        assert ec == 0
+
+    ballot_info = telosbookdex.get_ballot_by_feepayer(ballot_acc) 
+
+    assert ballot_info is not None
+    assert ballot_info['approved'] == 1
+    assert ballot_info['accepted'] == 1
+
+    config = telosbookdex.get_config()
+
+    assert int(config['bprune']) == max_entries
+
+
+def test_ballot_on_ballotsprune_no(telosdecide, telosbookdex):
+
+    old_max = int(telosbookdex.get_config()['bprune'])
+    new_max = 500
+
+    with telosbookdex.perform_vote(
+        telosdecide,
+        [['no']]
+    ) as vote_info:
+        voters, ballot_acc  = vote_info 
+        ec, out = telosbookdex.dao_ballotsprune(
+            new_max,
+            ballot_acc
+        )
+
+        assert ec == 0
+
+    ballot_info = telosbookdex.get_ballot_by_feepayer(ballot_acc) 
+
+    assert ballot_info is not None
+    assert ballot_info['approved'] == 0
+    assert ballot_info['accepted'] == 1
+
+    config = telosbookdex.get_config()
+
+    assert int(config['bprune']) == old_max

--- a/tests/telosbookdex/ballots/test_eventsprune.py
+++ b/tests/telosbookdex/ballots/test_eventsprune.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+from pytest_eosiocdt import name_to_string
+from pytest_eosiocdt.telos import telosdecide
+
+from ..constants import telosbookdex
+
+
+def test_ballot_on_eventsprune_yes(telosdecide, telosbookdex):
+
+    days = 10
+
+    with telosbookdex.perform_vote(
+        telosdecide,
+        [['yes']]
+    ) as vote_info:
+        voters, ballot_acc  = vote_info 
+        ec, out = telosbookdex.dao_eventsprune(
+            days,
+            ballot_acc
+        )
+
+        assert ec == 0
+
+    ballot_info = telosbookdex.get_ballot_by_feepayer(ballot_acc) 
+
+    assert ballot_info is not None
+    assert ballot_info['approved'] == 1
+    assert ballot_info['accepted'] == 1
+
+    config = telosbookdex.get_config()
+
+    assert int(config['eprune']) == days
+
+
+def test_ballot_on_eventsprune_no(telosdecide, telosbookdex):
+
+    old_days = int(telosbookdex.get_config()['eprune'])
+    new_days = 10
+
+    with telosbookdex.perform_vote(
+        telosdecide,
+        [['no']]
+    ) as vote_info:
+        voters, ballot_acc  = vote_info 
+        ec, out = telosbookdex.dao_eventsprune(
+            new_days,
+            ballot_acc
+        )
+
+        assert ec == 0
+
+    ballot_info = telosbookdex.get_ballot_by_feepayer(ballot_acc) 
+
+    assert ballot_info is not None
+    assert ballot_info['approved'] == 0
+    assert ballot_info['accepted'] == 1
+
+    config = telosbookdex.get_config()
+
+    assert int(config['eprune']) == old_days

--- a/tests/telosbookdex/ballots/test_hblockprune.py
+++ b/tests/telosbookdex/ballots/test_hblockprune.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+from pytest_eosiocdt import name_to_string
+from pytest_eosiocdt.telos import telosdecide
+
+from ..constants import telosbookdex
+
+
+def test_ballot_on_hblockprune_yes(telosdecide, telosbookdex):
+
+    days = 90
+
+    with telosbookdex.perform_vote(
+        telosdecide,
+        [['yes']]
+    ) as vote_info:
+        voters, ballot_acc  = vote_info 
+        ec, out = telosbookdex.dao_hblockprune(
+            days,
+            ballot_acc
+        )
+
+        assert ec == 0
+
+    ballot_info = telosbookdex.get_ballot_by_feepayer(ballot_acc) 
+
+    assert ballot_info is not None
+    assert ballot_info['approved'] == 1
+    assert ballot_info['accepted'] == 1
+
+    config = telosbookdex.get_config()
+
+    assert int(config['kprune']) == days
+
+
+def test_ballot_on_hblockprune_no(telosdecide, telosbookdex):
+
+    old_days = int(telosbookdex.get_config()['kprune'])
+    new_days = 90
+
+    with telosbookdex.perform_vote(
+        telosdecide,
+        [['no']]
+    ) as vote_info:
+        voters, ballot_acc  = vote_info 
+        ec, out = telosbookdex.dao_hblockprune(
+            new_days,
+            ballot_acc
+        )
+
+        assert ec == 0
+
+    ballot_info = telosbookdex.get_ballot_by_feepayer(ballot_acc) 
+
+    assert ballot_info is not None
+    assert ballot_info['approved'] == 0
+    assert ballot_info['accepted'] == 1
+
+    config = telosbookdex.get_config()
+
+    assert int(config['kprune']) == old_days

--- a/tests/telosbookdex/ballots/test_historyprune.py
+++ b/tests/telosbookdex/ballots/test_historyprune.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+from pytest_eosiocdt import name_to_string
+from pytest_eosiocdt.telos import telosdecide
+
+from ..constants import telosbookdex
+
+
+def test_ballot_on_historyprune_yes(telosdecide, telosbookdex):
+
+    days = 90
+
+    with telosbookdex.perform_vote(
+        telosdecide,
+        [['yes']]
+    ) as vote_info:
+        voters, ballot_acc  = vote_info 
+        ec, out = telosbookdex.dao_historyprune(
+            days,
+            ballot_acc
+        )
+
+        assert ec == 0
+
+    ballot_info = telosbookdex.get_ballot_by_feepayer(ballot_acc) 
+
+    assert ballot_info is not None
+    assert ballot_info['approved'] == 1
+    assert ballot_info['accepted'] == 1
+
+    config = telosbookdex.get_config()
+
+    assert int(config['hprune']) == days
+
+
+def test_ballot_on_historyprune_no(telosdecide, telosbookdex):
+
+    old_days = int(telosbookdex.get_config()['hprune'])
+    new_days = 90
+
+    with telosbookdex.perform_vote(
+        telosdecide,
+        [['no']]
+    ) as vote_info:
+        voters, ballot_acc  = vote_info 
+        ec, out = telosbookdex.dao_historyprune(
+            new_days,
+            ballot_acc
+        )
+
+        assert ec == 0
+
+    ballot_info = telosbookdex.get_ballot_by_feepayer(ballot_acc) 
+
+    assert ballot_info is not None
+    assert ballot_info['approved'] == 0
+    assert ballot_info['accepted'] == 1
+
+    config = telosbookdex.get_config()
+
+    assert int(config['hprune']) == old_days

--- a/tests/telosbookdex/ballots/test_makerfee.py
+++ b/tests/telosbookdex/ballots/test_makerfee.py
@@ -5,17 +5,17 @@ from pytest_eosiocdt.telos import telosdecide
 from ..constants import telosbookdex
 
 
-def test_ballot_on_setcurrency_yes(telosdecide, telosbookdex):
-    sym, prec, token_acc, token_acc_id = telosbookdex.init_test_token()
+def test_ballot_on_makerfee_yes(telosdecide, telosbookdex):
+    
+    new_fee = '0.00900000 FEE'
 
     with telosbookdex.perform_vote(
         telosdecide,
         [['yes']]
     ) as vote_info:
         voters, ballot_acc  = vote_info
-        ec, out = telosbookdex.dao_setcurrency(
-            sym,
-            'eosio.token',
+        ec, out = telosbookdex.dao_makerfee(
+            new_fee,
             ballot_acc
         )
 
@@ -27,27 +27,23 @@ def test_ballot_on_setcurrency_yes(telosdecide, telosbookdex):
     assert ballot_info['approved'] == 1
     assert ballot_info['accepted'] == 1
 
-    token_groups = telosbookdex.get_token_groups()
+    config = telosbookdex.get_config()
 
-    assert token_groups is not None
-    assert sym in token_groups[0]['currencies']
+    assert config['maker_fee'] == new_fee
 
 
-def test_ballot_on_setcurrency_no(telosdecide, telosbookdex):
-    sym, prec, token_acc, token_acc_id = telosbookdex.init_test_token()
-
-    # has to previously be a currency
-    ec, _ = telosbookdex.set_currency(sym, True, 0)
-    assert ec == 0
+def test_ballot_on_makerfee_no(telosdecide, telosbookdex):
+    
+    old_fee = telosbookdex.get_config()['maker_fee']
+    new_fee = '0.00900000 FEE'
 
     with telosbookdex.perform_vote(
         telosdecide,
         [['no']]
     ) as vote_info:
         voters, ballot_acc  = vote_info
-        ec, out = telosbookdex.dao_setcurrency(
-            sym,
-            'eosio.token',
+        ec, out = telosbookdex.dao_makerfee(
+            new_fee,
             ballot_acc
         )
 
@@ -59,7 +55,6 @@ def test_ballot_on_setcurrency_no(telosdecide, telosbookdex):
     assert ballot_info['approved'] == 0
     assert ballot_info['accepted'] == 1
 
-    token_groups = telosbookdex.get_token_groups()
+    config = telosbookdex.get_config()
 
-    assert token_groups is not None
-    assert sym not in token_groups[0]['currencies']
+    assert config['maker_fee'] == old_fee

--- a/tests/telosbookdex/ballots/test_pointsprune.py
+++ b/tests/telosbookdex/ballots/test_pointsprune.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+from pytest_eosiocdt import name_to_string
+from pytest_eosiocdt.telos import telosdecide
+
+from ..constants import telosbookdex
+
+
+def test_ballot_on_pointsprune_yes(telosdecide, telosbookdex):
+
+    weeks = 3
+
+    with telosbookdex.perform_vote(
+        telosdecide,
+        [['yes']]
+    ) as vote_info:
+        voters, ballot_acc  = vote_info 
+        ec, out = telosbookdex.dao_pointsprune(
+            weeks,
+            ballot_acc
+        )
+
+        assert ec == 0
+
+    ballot_info = telosbookdex.get_ballot_by_feepayer(ballot_acc) 
+
+    assert ballot_info is not None
+    assert ballot_info['approved'] == 1
+    assert ballot_info['accepted'] == 1
+
+    config = telosbookdex.get_config()
+
+    assert int(config['pprune']) == weeks
+
+
+def test_ballot_on_pointsprune_no(telosdecide, telosbookdex):
+
+    old_weeks = int(telosbookdex.get_config()['pprune'])
+    new_weeks = 3
+
+    with telosbookdex.perform_vote(
+        telosdecide,
+        [['no']]
+    ) as vote_info:
+        voters, ballot_acc  = vote_info 
+        ec, out = telosbookdex.dao_pointsprune(
+            new_weeks,
+            ballot_acc
+        )
+
+        assert ec == 0
+
+    ballot_info = telosbookdex.get_ballot_by_feepayer(ballot_acc) 
+
+    assert ballot_info is not None
+    assert ballot_info['approved'] == 0
+    assert ballot_info['accepted'] == 1
+
+    config = telosbookdex.get_config()
+
+    assert int(config['pprune']) == old_weeks

--- a/tests/telosbookdex/ballots/test_regcost.py
+++ b/tests/telosbookdex/ballots/test_regcost.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+from pytest_eosiocdt import name_to_string
+from pytest_eosiocdt.telos import telosdecide
+
+from ..constants import telosbookdex
+
+
+def test_ballot_on_regcost_yes(telosdecide, telosbookdex):
+
+    new_cost = 420
+
+    with telosbookdex.perform_vote(
+        telosdecide,
+        [['yes']]
+    ) as vote_info:
+        voters, ballot_acc  = vote_info 
+        ec, out = telosbookdex.dao_regcost(
+            f'{new_cost} TLOS',
+            ballot_acc
+        )
+
+        assert ec == 0
+
+    ballot_info = telosbookdex.get_ballot_by_feepayer(ballot_acc) 
+
+    assert ballot_info is not None
+    assert ballot_info['approved'] == 1
+    assert ballot_info['accepted'] == 1
+
+    config = telosbookdex.get_config()
+
+    assert config['regcost'] == f'0.{new_cost} TLOS'
+
+
+def test_ballot_on_regcost_no(telosdecide, telosbookdex):
+
+    old_cost = telosbookdex.get_config()['regcost']
+    new_cost = 420
+
+    with telosbookdex.perform_vote(
+        telosdecide,
+        [['no']]
+    ) as vote_info:
+        voters, ballot_acc  = vote_info 
+        ec, out = telosbookdex.dao_regcost(
+            f'{new_cost} TLOS',
+            ballot_acc
+        )
+
+        assert ec == 0
+
+    ballot_info = telosbookdex.get_ballot_by_feepayer(ballot_acc) 
+
+    assert ballot_info is not None
+    assert ballot_info['approved'] == 0
+    assert ballot_info['accepted'] == 1
+
+    config = telosbookdex.get_config()
+
+    assert config['regcost'] == old_cost

--- a/tests/telosbookdex/ballots/test_takerfee.py
+++ b/tests/telosbookdex/ballots/test_takerfee.py
@@ -5,17 +5,17 @@ from pytest_eosiocdt.telos import telosdecide
 from ..constants import telosbookdex
 
 
-def test_ballot_on_setcurrency_yes(telosdecide, telosbookdex):
-    sym, prec, token_acc, token_acc_id = telosbookdex.init_test_token()
+def test_ballot_on_takerfee_yes(telosdecide, telosbookdex):
+    
+    new_fee = '0.24000000 FEE'
 
     with telosbookdex.perform_vote(
         telosdecide,
         [['yes']]
     ) as vote_info:
         voters, ballot_acc  = vote_info
-        ec, out = telosbookdex.dao_setcurrency(
-            sym,
-            'eosio.token',
+        ec, out = telosbookdex.dao_takerfee(
+            new_fee,
             ballot_acc
         )
 
@@ -27,27 +27,23 @@ def test_ballot_on_setcurrency_yes(telosdecide, telosbookdex):
     assert ballot_info['approved'] == 1
     assert ballot_info['accepted'] == 1
 
-    token_groups = telosbookdex.get_token_groups()
+    config = telosbookdex.get_config()
 
-    assert token_groups is not None
-    assert sym in token_groups[0]['currencies']
+    assert config['taker_fee'] == new_fee
 
 
-def test_ballot_on_setcurrency_no(telosdecide, telosbookdex):
-    sym, prec, token_acc, token_acc_id = telosbookdex.init_test_token()
-
-    # has to previously be a currency
-    ec, _ = telosbookdex.set_currency(sym, True, 0)
-    assert ec == 0
+def test_ballot_on_takerfee_no(telosdecide, telosbookdex):
+    
+    old_fee = telosbookdex.get_config()['taker_fee']
+    new_fee = '0.24000000 FEE'
 
     with telosbookdex.perform_vote(
         telosdecide,
         [['no']]
     ) as vote_info:
         voters, ballot_acc  = vote_info
-        ec, out = telosbookdex.dao_setcurrency(
-            sym,
-            'eosio.token',
+        ec, out = telosbookdex.dao_takerfee(
+            new_fee,
             ballot_acc
         )
 
@@ -59,7 +55,6 @@ def test_ballot_on_setcurrency_no(telosdecide, telosbookdex):
     assert ballot_info['approved'] == 0
     assert ballot_info['accepted'] == 1
 
-    token_groups = telosbookdex.get_token_groups()
+    config = telosbookdex.get_config()
 
-    assert token_groups is not None
-    assert sym not in token_groups[0]['currencies']
+    assert config['taker_fee'] == old_fee

--- a/tests/telosbookdex/constants.py
+++ b/tests/telosbookdex/constants.py
@@ -507,6 +507,66 @@ class TelosBookDEX(SmartContract):
             feepayer
         )
 
+    def dao_historyprune(
+        self,
+        days: int,
+        feepayer: str
+    ):
+        return self.ballot_on(
+            'historyprune',
+            [days],
+            f'historyprune {days}',
+            feepayer
+        )
+
+    def dao_hblockprune(
+        self,
+        days: int,
+        feepayer: str
+    ):
+        return self.ballot_on(
+            'hblockprune',
+            [days],
+            f'hblockprune {days}',
+            feepayer
+        )
+
+    def dao_eventsprune(
+        self,
+        days: int,
+        feepayer: str
+    ):
+        return self.ballot_on(
+            'eventsprune',
+            [days],
+            f'eventsprune {days}',
+            feepayer
+        )
+
+    def dao_pointsprune(
+        self,
+        weeks: int,
+        feepayer: str
+    ):
+        return self.ballot_on(
+            'pointsprune',
+            [weeks],
+            f'pointsprune {weeks}',
+            feepayer
+        )
+
+    def dao_ballotsprune(
+        self,
+        max_entries: int,
+        feepayer: str
+    ):
+        return self.ballot_on(
+            'ballotsprune',
+            [max_entries],
+            f'ballotsprune {max_entries}',
+            feepayer
+        )
+
 
     @contextmanager
     def perform_vote(

--- a/tests/telosbookdex/constants.py
+++ b/tests/telosbookdex/constants.py
@@ -469,7 +469,6 @@ class TelosBookDEX(SmartContract):
             f'takerfee {amount}',
             feepayer
         )
-
      
     def dao_setcurrency(
         self,
@@ -481,6 +480,30 @@ class TelosBookDEX(SmartContract):
             'setcurrency',
             [symbol_code, contract],
             f'setcurrency {symbol_code} {contract}',
+            feepayer
+        )
+
+    def dao_regcost(
+        self,
+        cost: set,
+        feepayer: str
+    ):
+        return self.ballot_on(
+            'regcost',
+            [cost],
+            f'regcost {cost}',
+            feepayer
+        )
+
+    def dao_approvalmin(
+        self,
+        _min: float,
+        feepayer: str
+    ):
+        return self.ballot_on(
+            'approvalmin',
+            [_min],
+            f'approvalmin {_min}',
             feepayer
         )
 

--- a/tests/telosbookdex/constants.py
+++ b/tests/telosbookdex/constants.py
@@ -52,6 +52,9 @@ class TelosBookDEX(SmartContract):
             assert ec == 0 
             _did_init = True
 
+    def get_config(self):
+        return self.get_table(self.contract_name, 'state')[0];
+
     def new_client(
         self,
         admin: Optional[str] = None,
@@ -199,11 +202,11 @@ class TelosBookDEX(SmartContract):
             f'{admin}@active'
         )
 
-    def set_currency(self, admin: str, sym: str, value: bool, group: int):
+    def set_currency(self, sym: str, value: bool, group: int):
         return self.push_action(
             'setcurrency',
             [sym, value, group],
-            f'{admin}@active'
+            f'{self.contract_name}@active'
         )
 
     def get_token(self, symbol: str):
@@ -452,6 +455,18 @@ class TelosBookDEX(SmartContract):
             'makerfee',
             [amount],
             f'makerfee {amount}',
+            feepayer
+        )
+
+    def dao_takerfee(
+        self,
+        amount: str,
+        feepayer: str
+    ):
+        return self.ballot_on(
+            'takerfee',
+            [amount],
+            f'takerfee {amount}',
             feepayer
         )
 


### PR DESCRIPTION
This branch adds tests for the remaning ballots:

- `approvalmin`
- `ballotsprune`
- `eventsprune`
- `hblockprune`
- `historyprune`
- `makerfee`
- `takerfee`
- `pointsprune`
- `regcost`

Also some fixes and improvements to `setcurrency` ballot test.