### PR TITLE
Fixes to setcurrency ballot result handler

### DIFF
--- a/include/vapaee/dex/modules/dao.hpp
+++ b/include/vapaee/dex/modules/dao.hpp
@@ -791,13 +791,25 @@ namespace vapaee {
                 auto ptr = token_table.find(sym_code.raw());
                 check(ptr != token_table.end(), create_error_symcode1(ERROR_HBRFSC_1, sym_code).c_str());
                 check(ptr->contract == tcontract, create_error_name2(ERROR_HBRFSC_2, ptr->contract, tcontract).c_str());
-                
-                action(
-                    permission_level{contract,name("active")},
-                    contract,
-                    name("setcurrency"),
-                    std::make_tuple(sym_code, approved, (uint64_t)0)
-                ).send();                 
+              
+                tokengroups groupstable(contract, contract.value);
+                auto it = groupstable.find(0); // token group 0
+                check(it != groupstable.end(), create_error_symcode1(ERROR_ASTAC_1, sym_code).c_str());
+               
+                bool is_currency = std::find(
+                    it->currencies.begin(),
+                    it->currencies.end(),
+                    sym_code
+                ) != it->currencies.end();
+
+                if (is_currency != approved) {
+                    action(
+                        permission_level{contract,name("active")},
+                        contract,
+                        name("setcurrency"),
+                        std::make_tuple(sym_code, approved, (uint64_t)0)
+                    ).send();
+                }
 
                 PRINT("vapaee::dex::dao::handler_ballot_result_for_setcurrency() ...\n");
             }

--- a/tests/telosbookdex/ballots/test_setcurrency.py
+++ b/tests/telosbookdex/ballots/test_setcurrency.py
@@ -5,7 +5,7 @@ from pytest_eosiocdt.telos import telosdecide
 from ..constants import telosbookdex
 
 
-def test_ballot_on_setcurrency_yes(telosdecide, telosbookdex):
+def test_ballot_on_setcurrency_yes_non_currency(telosdecide, telosbookdex):
     sym, prec, token_acc, token_acc_id = telosbookdex.init_test_token()
 
     with telosbookdex.perform_vote(
@@ -33,12 +33,82 @@ def test_ballot_on_setcurrency_yes(telosdecide, telosbookdex):
     assert sym in token_groups[0]['currencies']
 
 
-def test_ballot_on_setcurrency_no(telosdecide, telosbookdex):
+def test_ballot_on_setcurrency_no_non_currency(telosdecide, telosbookdex):
+    sym, prec, token_acc, token_acc_id = telosbookdex.init_test_token()
+
+    with telosbookdex.perform_vote(
+        telosdecide,
+        [['no']]
+    ) as vote_info:
+        voters, ballot_acc  = vote_info
+        ec, out = telosbookdex.dao_setcurrency(
+            sym,
+            'eosio.token',
+            ballot_acc
+        )
+
+        assert ec == 0
+
+    ballot_info = telosbookdex.get_ballot_by_feepayer(ballot_acc) 
+
+    assert ballot_info is not None
+    assert ballot_info['approved'] == 0
+    assert ballot_info['accepted'] == 1
+
+    token_groups = telosbookdex.get_token_groups()
+
+    assert token_groups is not None
+    assert sym not in token_groups[0]['currencies']
+
+
+def test_ballot_on_setcurrency_yes_currency(telosdecide, telosbookdex):
     sym, prec, token_acc, token_acc_id = telosbookdex.init_test_token()
 
     # has to previously be a currency
     ec, _ = telosbookdex.set_currency(sym, True, 0)
     assert ec == 0
+
+    token_groups = telosbookdex.get_token_groups()
+
+    assert token_groups is not None
+    assert sym in token_groups[0]['currencies']
+
+    with telosbookdex.perform_vote(
+        telosdecide,
+        [['yes']]
+    ) as vote_info:
+        voters, ballot_acc  = vote_info
+        ec, out = telosbookdex.dao_setcurrency(
+            sym,
+            'eosio.token',
+            ballot_acc
+        )
+
+        assert ec == 0
+
+    ballot_info = telosbookdex.get_ballot_by_feepayer(ballot_acc) 
+
+    assert ballot_info is not None
+    assert ballot_info['approved'] == 1
+    assert ballot_info['accepted'] == 1
+
+    token_groups = telosbookdex.get_token_groups()
+
+    assert token_groups is not None
+    assert sym in token_groups[0]['currencies']
+
+
+def test_ballot_on_setcurrency_no_currency(telosdecide, telosbookdex):
+    sym, prec, token_acc, token_acc_id = telosbookdex.init_test_token()
+
+    # has to previously be a currency
+    ec, _ = telosbookdex.set_currency(sym, True, 0)
+    assert ec == 0
+
+    token_groups = telosbookdex.get_token_groups()
+
+    assert token_groups is not None
+    assert sym in token_groups[0]['currencies']
 
     with telosbookdex.perform_vote(
         telosdecide,


### PR DESCRIPTION
Closes #28 

Fix proposed adds a boolean check to know if the affected token is already a currency or not:
```c++
tokengroups groupstable(contract, contract.value);
auto it = groupstable.find(0); // token group 0
check(it != groupstable.end(), create_error_symcode1(ERROR_ASTAC_1, sym_code).c_str());

bool is_currency = std::find(
    it->currencies.begin(),
    it->currencies.end(),
    sym_code
) != it->currencies.end()
```
Then we `xor` it with the result of the ballot, as we only need to change the currency status of the token if the results of the ballot are different from its current status:
```c++
if (is_currency != approved) {
    action(
        permission_level{contract,name("active")},
        contract,
        name("setcurrency"),
        std::make_tuple(sym_code, approved, (uint64_t)0)
    ).send();
}
```