### PR TITLE
Make maintenance rewards manageable by ballot

### DIFF
--- a/include/vapaee/dex/modules/exchange.hpp
+++ b/include/vapaee/dex/modules/exchange.hpp
@@ -220,14 +220,16 @@ namespace vapaee {
                 PRINT(" tlos_volume: ", tlos_volume.to_string(), "\n");
 
                 double unit = (double)pow(10.0, tlos_volume.symbol.precision());
-                double realamount = ( (double)tlos_volume.amount / unit );
+                double realamount = (double)tlos_volume.amount / unit;
+
+                state global_config = vapaee::dex::global::get();
                 
                 PRINT(" -> realamount: ", std::to_string(realamount), "\n");
                 if (tlos_volume.amount > 0) {
-                    uint64_t mpts = (uint64_t) (realamount * 1.0);
-                    uint64_t mexp = (uint64_t) (realamount * 0.5);
-                    uint64_t tpts = (uint64_t) (realamount * 2.0);
-                    uint64_t texp = (uint64_t) (realamount * 1.0);
+                    uint64_t mpts = (uint64_t) (realamount * global_config.maker_pts_reward);
+                    uint64_t mexp = (uint64_t) (realamount * global_config.maker_exp_reward);
+                    uint64_t tpts = (uint64_t) (realamount * global_config.taker_pts_reward);
+                    uint64_t texp = (uint64_t) (realamount * global_config.taker_exp_reward);
 
                     PRINT(" -> mpts: ", std::to_string((unsigned long)mpts), "\n");
                     PRINT(" -> mexp: ", std::to_string((unsigned long)mexp), "\n");

--- a/include/vapaee/dex/modules/experience.hpp
+++ b/include/vapaee/dex/modules/experience.hpp
@@ -77,7 +77,7 @@ namespace vapaee {
                 }
 
                 // search for the latest week entry for this user (iteration)
-                // does exist an entry for this week?
+                // does an entry for this week exist?
                 // if so, update the number
                 // if not, create a new one
                 points pointstable(contract, contract.value);
@@ -95,7 +95,7 @@ namespace vapaee {
                 }
 
                 if (itr != index.end()) {
-                    PRINT(" exp.modify() .points += ",points_reward.to_string(),"\n");
+                    PRINT(" points.modify() .points += ",points_reward.to_string(),"\n");
                     pointstable.modify(*itr, same_payer, [&](auto &a){
                         a.points += points_reward;
                     });

--- a/include/vapaee/dex/modules/global.hpp
+++ b/include/vapaee/dex/modules/global.hpp
@@ -35,6 +35,23 @@ namespace vapaee {
                 entry_stored.pprune = conf.pprune;
                 entry_stored.approvalmin = conf.approvalmin;
                 entry_stored.regcost = conf.regcost;
+                entry_stored.maker_pts_reward = conf.maker_pts_reward;
+                entry_stored.maker_exp_reward = conf.maker_exp_reward;
+                entry_stored.taker_pts_reward = conf.taker_pts_reward;
+                entry_stored.taker_exp_reward = conf.taker_exp_reward;
+
+                entry_stored.maint_reward_delmarkets_exp = conf.maint_reward_delmarkets_exp;
+                entry_stored.maint_reward_history_exp = conf.maint_reward_history_exp;
+                entry_stored.maint_reward_events_exp = conf.maint_reward_events_exp;
+                entry_stored.maint_reward_points_exp = conf.maint_reward_points_exp;
+                entry_stored.maint_reward_ballots_exp = conf.maint_reward_ballots_exp;
+
+                entry_stored.maint_reward_delmarkets_pts = conf.maint_reward_delmarkets_pts;
+                entry_stored.maint_reward_history_pts = conf.maint_reward_history_pts;
+                entry_stored.maint_reward_events_pts = conf.maint_reward_events_pts;
+                entry_stored.maint_reward_points_pts = conf.maint_reward_points_pts;
+                entry_stored.maint_reward_ballots_pts = conf.maint_reward_ballots_pts;
+
                 entry_stored.next_market = conf.next_market;
                 AUX_DEBUG_CODE(entry_stored.time_offset = conf.time_offset;)
                 get_singleton().set(entry_stored, contract);
@@ -87,8 +104,25 @@ namespace vapaee {
                 new_state.bprune = 1000;      // no more than 1000 entries allowed in the ballots table.
                 new_state.eprune = 60;        // 60 days old event should be considered expired and must be deleted
                 new_state.pprune = 6;         // 6 weeks old points should be considered expired and must be deleted
-                new_state.approvalmin = 0.25; // 25% of participation must be reached in order to approve a ballot
+                new_state.approvalmin = .25f; // 25% of participation must be reached in order to approve a ballot
                 new_state.regcost = asset(1000000, system_symbol);
+                new_state.maker_pts_reward = 1;
+                new_state.maker_exp_reward = .5f;
+                new_state.taker_pts_reward = 2;
+                new_state.taker_exp_reward = 1;
+
+                new_state.maint_reward_delmarkets_exp = 1;
+                new_state.maint_reward_history_exp = 1;
+                new_state.maint_reward_events_exp = .5f;
+                new_state.maint_reward_points_exp = .5f;
+                new_state.maint_reward_ballots_exp = 1;
+
+                new_state.maint_reward_delmarkets_pts = 1;
+                new_state.maint_reward_history_pts = 1;
+                new_state.maint_reward_events_pts = 2;
+                new_state.maint_reward_points_pts = 2;
+                new_state.maint_reward_ballots_pts = 1;
+
                 new_state.next_market = 0;
                 AUX_DEBUG_CODE(new_state.time_offset = 0;)
 

--- a/include/vapaee/dex/modules/maintenance.hpp
+++ b/include/vapaee/dex/modules/maintenance.hpp
@@ -46,7 +46,7 @@ namespace vapaee {
                 userorders buyerorders(contract, owner.value);
                 auto buyer_itr = buyerorders.find(market);
                 
-                check(buyer_itr != buyerorders.end(), "ERROR: cómo que no existe? No fue registrado antes?");
+                check(buyer_itr != buyerorders.end(), "ERROR: how can it not exist? wasn't it registered before?");
                 // take the order out of the buyer personal order registry
                 buyerorders.modify(*buyer_itr, same_payer, [&](auto & a){
                     std::vector<uint64_t> newlist;
@@ -87,7 +87,9 @@ namespace vapaee {
                 PRINT("vapaee::dex::maintenance::aux_maintenance_from_delmarkets()\n");
                 PRINT(" pts: ", pts.to_string(), "\n");
                 PRINT(" exp: ", exp.to_string(), "\n");
-                
+               
+                state gconf = vapaee::dex::global::get(); 
+
                 string report;
                 delmarkets deltable(contract, contract.value);
                 auto delptr = deltable.begin();
@@ -119,8 +121,8 @@ namespace vapaee {
 
                         PRINT("  => historyall.erase(): ",std::to_string((unsigned long)hall_ptr->id), "\n");
                         hall_table.erase(*hall_ptr);
-                        exp.amount += 5;
-                        pts.amount += 5;
+                        exp.amount += 5 * gconf.maint_reward_delmarkets_exp;
+                        pts.amount += 5 * gconf.maint_reward_delmarkets_pts;
                     } else {
                         PRINT(" -> history_clean \n");
                         history_clean = true;
@@ -133,8 +135,8 @@ namespace vapaee {
                         report += string("|delmarket-cancel-order:")+ std::to_string((unsigned long)sptr->id)  + "," + std::to_string((unsigned long)market_id);
                         PRINT("  => cancel_sell_order(): ",sptr->owner.to_string(), " id: ", std::to_string((unsigned long)sptr->id), " market: ", std::to_string((unsigned long)market_id), "\n"); 
                         aux_cancel_sell_order(sptr->owner, sptr->id, market_id);
-                        exp.amount += 5;
-                        pts.amount += 5;
+                        exp.amount += 5 * gconf.maint_reward_delmarkets_exp;
+                        pts.amount += 5 * gconf.maint_reward_delmarkets_pts;
                     } else {
                         PRINT(" -> sellorders_clean \n");
                         sellorders_clean = true;
@@ -144,8 +146,8 @@ namespace vapaee {
                         PRINT("  => delmarkets.erase(): ",std::to_string((unsigned long)delptr->id), " DELETE delmarket!!!!\n");
                         report += string("|delmarket-erase-market:") + std::to_string((unsigned long)market_id);
                         deltable.erase(*delptr);
-                        exp.amount += 3;
-                        pts.amount += 5;
+                        exp.amount += 3 * gconf.maint_reward_delmarkets_exp;
+                        pts.amount += 5 * gconf.maint_reward_delmarkets_pts;
                     }
 
                 }
@@ -157,6 +159,8 @@ namespace vapaee {
                 PRINT("vapaee::dex::maintenance::aux_maintenance_from_history()\n");
                 PRINT(" pts: ", pts.to_string(), "\n");
                 PRINT(" exp: ", exp.to_string(), "\n");
+
+                state gconf = vapaee::dex::global::get(); 
 
                 string report;
                 int hprune_days = vapaee::dex::global::get().hprune;
@@ -183,8 +187,8 @@ namespace vapaee {
                         PRINT(" => historyall.erase(): ",std::to_string((unsigned long)hall_ptr->id)," \n");
                         h_table.erase(*h_ptr);
                         hall_table.erase(*hall_ptr);
-                        exp.amount += 4;
-                        pts.amount += 6;
+                        exp.amount += 4 * gconf.maint_reward_history_exp;
+                        pts.amount += 6 * gconf.maint_reward_history_pts;
                     }
                 }
                 
@@ -195,8 +199,8 @@ namespace vapaee {
                         report += string("|historyblock-prune:") + std::to_string((unsigned long)blocks_ptr->id) + "," + std::to_string((unsigned long)blocks_ptr->hour);
                         PRINT(" => historyblock.erase(): ",std::to_string((unsigned long)blocks_ptr->id)," \n");
                         blocks_table.erase(*blocks_ptr);
-                        exp.amount += 8;
-                        pts.amount += 10;                        
+                        exp.amount += 8 * gconf.maint_reward_history_exp;
+                        pts.amount += 10 * gconf.maint_reward_history_pts;                      
                     }
                 }
 
@@ -208,6 +212,8 @@ namespace vapaee {
                 PRINT("vapaee::dex::maintenance::aux_maintenance_from_events()\n");
                 PRINT(" pts: ", pts.to_string(), "\n");
                 PRINT(" exp: ", exp.to_string(), "\n");
+
+                state gconf = vapaee::dex::global::get(); 
                 
                 string report;
                 int eprune_days = vapaee::dex::global::get().eprune;
@@ -237,8 +243,8 @@ namespace vapaee {
                 }
                 if (count>0) {
                     report += string("|events-prune:") + std::to_string(count);
-                    exp.amount += (uint64_t)(((float)count)/2.0);
-                    pts.amount += count*2;                    
+                    exp.amount += count * gconf.maint_reward_events_exp;
+                    pts.amount += count * gconf.maint_reward_events_pts;
                 }
 
                 PRINT("vapaee::dex::maintenance::aux_maintenance_from_events() ...\n");
@@ -249,6 +255,8 @@ namespace vapaee {
                 PRINT("vapaee::dex::maintenance::aux_maintenance_from_points()\n");
                 PRINT(" pts: ", pts.to_string(), "\n");
                 PRINT(" exp: ", exp.to_string(), "\n");
+
+                state gconf = vapaee::dex::global::get(); 
 
                 string report;
                 int pprune_weeks = vapaee::dex::global::get().pprune;
@@ -277,8 +285,8 @@ namespace vapaee {
                 }
                 if (count>0) {
                     report += string("|points-prune:") + std::to_string(count);
-                    exp.amount += (uint64_t)(((float)count)/2.0);
-                    pts.amount += count*2;                
+                    exp.amount += count * gconf.maint_reward_events_exp;
+                    pts.amount += count * gconf.maint_reward_events_pts;
                 }
 
                 PRINT("vapaee::dex::maintenance::aux_maintenance_from_points() ...\n");
@@ -289,6 +297,8 @@ namespace vapaee {
                 PRINT("vapaee::dex::maintenance::aux_maintenance_from_ballots()\n");
                 PRINT(" pts: ", pts.to_string(), "\n");
                 PRINT(" exp: ", exp.to_string(), "\n");
+
+                state gconf = vapaee::dex::global::get(); 
                 
                 string report;
                 int bprune = vapaee::dex::global::get().bprune;
@@ -313,8 +323,8 @@ namespace vapaee {
                             report += string("|ballots-prune:") + ptr->ballot_name.to_string();
                             PRINT("  => ballots.erase(): ",std::to_string((unsigned long)ptr->id), "\n");
                             balltable.erase(*ptr);
-                            exp.amount += 5;
-                            pts.amount += 10;                            
+                            exp.amount += 5 * gconf.maint_reward_events_exp;
+                            pts.amount += 10 * gconf.maint_reward_events_pts;                            
                         } else {
                             PRINT(" -> we skip ballot because is not finished: ",std::to_string((unsigned long)ptr->id)," \n");         
                         }                       

--- a/include/vapaee/dex/tables/state.hpp
+++ b/include/vapaee/dex/tables/state.hpp
@@ -1,21 +1,38 @@
 #include "./_aux.hpp"
 
-        // scope: singleton
-        TABLE state {
-            asset maker_fee;
-            asset taker_fee;
-            int hprune;  // amount of days in which a HISTORY entry must be considered expired and must be removed 
-            int kprune;  // amount of days in which a HISTORY BLOCKS entry must be considered expired and must be removed 
-            int bprune;  // amount of maximun finished BALLOT entries allowed.
-            int eprune;  // amount of days in which a EVENT entry must be considered expired and must be removed 
-            int pprune;  // amount of weeks in which a POINTS entry must be considered expired and must be removed 
-            float approvalmin; // minimum participation percentage for ballot approval
-            asset regcost; // token registration cost (in TLOS)
+// scope: singleton
+TABLE state {
+    asset maker_fee;
+    asset taker_fee;
+    int hprune;  // amount of days in which a HISTORY entry must be considered expired and must be removed 
+    int kprune;  // amount of days in which a HISTORY BLOCKS entry must be considered expired and must be removed 
+    int bprune;  // amount of maximun finished BALLOT entries allowed.
+    int eprune;  // amount of days in which a EVENT entry must be considered expired and must be removed 
+    int pprune;  // amount of weeks in which a POINTS entry must be considered expired and must be removed 
+    float approvalmin; // minimum participation percentage for ballot approval
+    asset regcost; // token registration cost (in TLOS)
+    
+    float maker_pts_reward; // trading points reward multiplier
+    float maker_exp_reward; // trading experience reward multiplier
+    float taker_pts_reward; // trading points reward multiplier
+    float taker_exp_reward; // trading experience reward multiplier
 
-            // This property is here because we can't reutilize ids for markets. If a token gets blacklisted,
-            // all the markets involving that token will be slowly cleaned up by the maintenance process.
-            // If we create a new market reusing the id of the deletedone, we may end up "cleaning up" the wrong market
-            uint64_t next_market; // id of the next market
-            AUX_DEBUG_CODE(uint32_t time_offset;)
-        };
-        typedef singleton<name("state"), state> global_state_singleton;
+    float maint_reward_delmarkets_exp;
+    float maint_reward_history_exp;
+    float maint_reward_events_exp;
+    float maint_reward_points_exp;
+    float maint_reward_ballots_exp;
+
+    float maint_reward_delmarkets_pts;
+    float maint_reward_history_pts;
+    float maint_reward_events_pts;
+    float maint_reward_points_pts;
+    float maint_reward_ballots_pts;
+
+    // This property is here because we can't reutilize ids for markets. If a token gets blacklisted,
+    // all the markets involving that token will be slowly cleaned up by the maintenance process.
+    // If we create a new market reusing the id of the deletedone, we may end up "cleaning up" the wrong market
+    uint64_t next_market; // id of the next market
+    AUX_DEBUG_CODE(uint32_t time_offset;)
+};
+typedef singleton<name("state"), state> global_state_singleton;

--- a/tests/telosbookdex/ballots/test_setreward.py
+++ b/tests/telosbookdex/ballots/test_setreward.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+
+import pytest
+
+from pytest_eosiocdt.telos import telosdecide
+
+from ..constants import telosbookdex
+
+
+reward_names = (
+    'trademaker',
+    'tradetaker',
+    'delmarkets',
+    'history',
+    'events',
+    'points',
+    'ballots'
+)
+
+config_names = (
+    'maker_X_reward',
+    'taker_X_reward',
+    'maint_reward_delmarkets_X',
+    'maint_reward_history_X',
+    'maint_reward_events_X',
+    'maint_reward_points_X',
+    'maint_reward_ballots_X'
+)
+
+reward_types = ('pts', 'exp')
+
+params = []
+for reward_type in reward_types:
+    for reward_name, config_name in zip(
+        reward_names, config_names
+    ):
+        params.append((
+            reward_name,
+            config_name.replace('X', reward_type),
+            reward_type
+        ))
+
+@pytest.mark.parametrize(
+    'reward_name,config_name,reward_type',
+    [pytest.param(param[0], param[1], param[2], id=param[1])
+    for param in params]
+)
+def test_ballot_on_setreward_yes(
+    telosdecide,
+    telosbookdex,
+    reward_name, config_name, reward_type
+):
+    """Approve ballot to change reward multiplier global config setting & check
+    respective table for correct update
+    """
+    new_rew = .75
+
+    with telosbookdex.perform_vote(
+        telosdecide,
+        [['yes']]
+    ) as vote_info:
+        voters, ballot_acc  = vote_info 
+        ec, out = telosbookdex.dao_setreward(
+            reward_name,
+            reward_type,
+            new_rew,
+            ballot_acc
+        )
+
+        assert ec == 0
+
+    ballot_info = telosbookdex.get_ballot_by_feepayer(ballot_acc) 
+
+    assert ballot_info is not None
+    assert ballot_info['approved'] == 1
+    assert ballot_info['accepted'] == 1
+
+    config = telosbookdex.get_config()
+
+    assert float(config[config_name]) == new_rew
+
+
+@pytest.mark.parametrize(
+    'reward_name,config_name,reward_type',
+    [pytest.param(param[0], param[1], param[2], id=param[1])
+    for param in params]
+)
+def test_ballot_on_setreward_no(
+    telosdecide,
+    telosbookdex,
+    reward_name, config_name, reward_type
+):
+    """Attempt ballot to change reward multiplier global config setting (but
+    fail) & check value stays the same
+    """
+    old_rew = float(telosbookdex.get_config()[config_name])
+    new_rew = .75
+
+    with telosbookdex.perform_vote(
+        telosdecide,
+        [['no']]
+    ) as vote_info:
+        voters, ballot_acc  = vote_info 
+        ec, out = telosbookdex.dao_setreward(
+            reward_name,
+            reward_type,
+            new_rew,
+            ballot_acc
+        )
+
+        assert ec == 0
+
+    ballot_info = telosbookdex.get_ballot_by_feepayer(ballot_acc) 
+
+    assert ballot_info is not None
+    assert ballot_info['approved'] == 0
+    assert ballot_info['accepted'] == 1
+
+    config = telosbookdex.get_config()
+
+    assert float(config[config_name]) == old_rew

--- a/tests/telosbookdex/constants.py
+++ b/tests/telosbookdex/constants.py
@@ -112,6 +112,30 @@ class TelosBookDEX(SmartContract):
         else:
             return ec, out
 
+    def get_client_experience(self, client: str):
+        exptable = self.get_table(
+            self.contract_name,
+            'exp'
+        )
+        return next((
+            row['exp'] for row in exptable
+            if row['owner'] == client),
+            None
+        )
+
+    def get_client_points(self, client: str):
+        return [
+            row['points']
+            for row in self.get_table(
+                self.contract_name,
+                'points',
+                '--index', '3',  # 'owner'
+                '--lower', client,
+                '--key-type', 'name'
+            )
+            if row['owner'] == client
+        ]
+
     def get_token_groups(self):
         return self.get_table(
             self.contract_name,
@@ -308,7 +332,7 @@ class TelosBookDEX(SmartContract):
                 client_id
             ],
             f'{owner}@active',
-            retry=5
+            retry=10
         )
 
     def get_history(self, sym_a: str, sym_b: str):
@@ -591,7 +615,20 @@ class TelosBookDEX(SmartContract):
             f'ballotsprune {max_entries}',
             feepayer
         )
-
+    
+    def dao_setreward(
+        self,
+        name: str,
+        _type: str,
+        value: float,
+        feepayer: str
+    ):
+        return self.ballot_on(
+            'setreward',
+            [name, _type, value],
+            f'setreward {name} {_type} {value}',
+            feepayer
+        )
 
     @contextmanager
     def perform_vote(

--- a/tests/telosbookdex/test_order.py
+++ b/tests/telosbookdex/test_order.py
@@ -7,7 +7,7 @@ from .constants import telosbookdex
 
 def test_order(telosbookdex):
     """Perform order execution and check that the order book gets updated
-    correctly.
+    correctly. Also check user reward tables
     """
     # setup token & seller account
     supply = 1000
@@ -82,3 +82,19 @@ def test_order(telosbookdex):
 
     assert len(buy_table) == 0
     assert len(sell_table) == 0
+
+    # check rewards
+    config = telosbookdex.get_config()
+
+    maker_exp = int(telosbookdex.get_client_experience(seller).split(' ')[0])
+    maker_pts = int(telosbookdex.get_client_points(seller)[0].split(' ')[0])
+
+    taker_exp = int(telosbookdex.get_client_experience(buyer).split(' ')[0])
+    taker_pts = int(telosbookdex.get_client_points(buyer)[0].split(' ')[0])
+
+    assert maker_exp == total * float(config['maker_exp_reward'])
+    assert maker_pts == total * float(config['maker_pts_reward'])
+
+    assert taker_exp == total * float(config['taker_exp_reward'])
+    assert taker_pts == total * float(config['taker_pts_reward'])
+


### PR DESCRIPTION
Closes #22

Added a multiplier for each maintenance reward, which can be set by ballot.

This PR includes tests for each ballot.