### PR TITLE
Rename link table id from 'link_id' to 'id' to follow naming convention

### DIFF
--- a/include/vapaee/tprofile/modules/link.hpp
+++ b/include/vapaee/tprofile/modules/link.hpp
@@ -47,7 +47,7 @@ namespace vapaee {
                 
 
                 link_table.emplace(owner, [&](auto& row) {
-                    row.link_id = link_table.available_primary_key();
+                    row.id = link_table.available_primary_key();
                     row.platform_id = plat_it->id;
                     row.url = url;
                     row.token = token;

--- a/include/vapaee/tprofile/tables/links.hpp
+++ b/include/vapaee/tprofile/tables/links.hpp
@@ -8,19 +8,19 @@
 #define MAX_WITNESS 5
 
 TABLE link_t {
-    uint64_t           link_id;  // auto-increment
-    uint64_t       platform_id;  // relational id to row in platform table
-    string                 url;  // link to an external platform or website page related with this profile
-    string               proof;  // link to a specific publication in which apears the "alias" auto-generated random slug id.
-    string               token;  // auto-generated proof token
+    uint64_t id;          // auto-increment
+    uint64_t platform_id; // relational id to row in platform table
+    string   url;         // link to an external platform or website page related with this profile
+    string   proof;       // link to a specific publication in which apears the "alias" auto-generated random slug id.
+    string   token;       // auto-generated proof token
 
-    uint64_t            points;  // total sum of the profile scores witnessing this link
+    uint64_t points;  // total sum of the profile scores witnessing this link
     
     // list of {points, profile_id} that witnessed this link
     vector<tuple<uint64_t, uint64_t>> witnesses;
 
     uint64_t primary_key() const {
-        return link_id;
+        return id;
     }
 
     uint64_t by_platform() const { 

--- a/tests/telosprofile/constants.py
+++ b/tests/telosprofile/constants.py
@@ -130,7 +130,7 @@ class TelosProfile:
 
         return next((
             row for row in links
-            if row['link_id'] == link_id),
+            if row['id'] == link_id),
             None
         )
 

--- a/tests/telosprofile/test_chglink.py
+++ b/tests/telosprofile/test_chglink.py
@@ -24,7 +24,7 @@ def test_chglink(telosprofile):
     link = telosprofile.get_link_with_proof(alias, proof_token)
     assert link is not None
 
-    link_id = link['link_id']
+    link_id = link['id']
 
     new_url = 'https://localhost/facebook2.html'
 

--- a/tests/telosprofile/test_prooflink.py
+++ b/tests/telosprofile/test_prooflink.py
@@ -18,7 +18,7 @@ def test_prooflink(telosprofile):
     assert len(proof) == 12
 
     link = telosprofile.get_link_with_proof(alias, proof)
-    link_id = link['link_id']
+    link_id = link['id']
 
     proof_url = 'steemit.io/profiles.html?user=mario?postid=06283688886909'
 

--- a/tests/telosprofile/test_witness.py
+++ b/tests/telosprofile/test_witness.py
@@ -29,7 +29,7 @@ def test_witness(telosprofile):
     assert link['points'] == 0
 
     # create several accounts that witness the link
-    link_id = link['link_id']
+    link_id = link['id']
 
     bot_accounts = 5
 
@@ -57,7 +57,7 @@ def test_witness(telosprofile):
     assert link is not None
 
     # witness this new link with root account
-    link_id = link['link_id']
+    link_id = link['id']
     telosprofile.witness_link(alias_link, new_alias, link_id)
 
     link = telosprofile.get_link_with_id(new_alias, link_id)


### PR DESCRIPTION
Closes #34

Another simple one, had to modify a few tests apart from the table itself.