### PR TITLE
koinonospool implementation & basic test

### DIFF
--- a/contracts/koinonospool/CMakeLists.txt
+++ b/contracts/koinonospool/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.5)
+project(koinonos_pool VERSION 0.1.0)
+set(EOSIO_WASM_OLD_BEHAVIOR "Off")
+find_package(eosio.cdt)
+include(EosioWasmToolchain)
+
+add_contract(koinonospool koinonospool koinonospool.cpp)
+
+file(GLOB custom_includes ${CUSTOM_INCLUDES_DIR}/*)
+target_include_directories(koinonospool PUBLIC ${custom_includes})

--- a/contracts/koinonospool/errors.hpp
+++ b/contracts/koinonospool/errors.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+static const char* EMPTY_MEMO_ERR = "memo can't be empty";
+static const char* INCORRECT_MEMO_ERR = "incorrect memo format";
+static const char* WRONG_PROTOCOL_ERR = "incorrect protocol string";
+static const char* MIN_FIELD_PARSE_ERR = "couldn't parse min paramenter";
+static const char* POOL_NOT_FOUND_ERR = "pool not found";
+static const char* UNFUNDED_POOL_ERR = "unfunded pool";
+static const char* BAD_DEAL_ERR = "total less than minimun";

--- a/contracts/koinonospool/koinonospool.cpp
+++ b/contracts/koinonospool/koinonospool.cpp
@@ -1,0 +1,134 @@
+#include "koinonospool.hpp"
+
+using std::stoi;
+using std::remove;
+using std::make_tuple;
+
+using eosio::check;
+using eosio::action;
+using eosio::symbol_code;
+using eosio::require_auth;
+using eosio::permission_level;
+
+
+void koinonospool::initpool(
+    name admin,
+    name token_contract,
+    symbol token_sym
+) {
+    require_auth(get_self());
+    require_auth(admin);
+
+    poolinfo_t pools(get_self(), get_self().value);
+
+    auto sym_index = pools.get_index<"sym"_n>();
+    auto pool_it = sym_index.find(token_sym.raw());
+    check(pool_it == sym_index.end(), "pool for symbol already exists");
+
+    pools.emplace(admin, [&](auto& row) {
+        row.id = pools.available_primary_key();
+        row.admin = admin;
+        row.token_contract = token_contract;
+        row.reserve = asset(0, token_sym); 
+    });
+}
+
+void koinonospool::transaction_handler(
+    name from,
+    name to,
+    asset quantity, string memo
+) {
+    /*
+     * skip handling if:
+     *
+     *  - transaction comes from self
+     *  - transaction is not destined to self
+     *  - memo is "skip"
+     */
+    if (from == get_self() ||
+        to != get_self() ||
+        memo == "skip")
+        return;
+
+    poolinfo_t pools(get_self(), get_self().value);
+    auto sym_index = pools.get_index<"sym"_n>();
+
+    if (memo == "fund") {
+        auto pool_it = sym_index.find(quantity.symbol.raw());
+        check(pool_it != sym_index.end(), POOL_NOT_FOUND_ERR);
+
+        sym_index.modify(pool_it, pool_it->admin, [&](auto& row) {
+            row.reserve += quantity;
+        });
+        return;
+    }
+
+    check(!memo.empty(), EMPTY_MEMO_ERR);
+
+    // koinonos protocol parsing
+    vector<string> tokens = split(memo, ",");
+
+    check(tokens.size() == 3, INCORRECT_MEMO_ERR);
+    
+    string version = tokens[0];
+    check(version == PROTO_VERSION, WRONG_PROTOCOL_ERR);
+   
+    // minimun quantity asset parsing
+    string min = tokens[1];
+    vector<string> min_asset_tokens = split(min, " ");
+    check(min_asset_tokens.size() == 2, MIN_FIELD_PARSE_ERR);
+
+    string str_amount = min_asset_tokens[0];
+    string str_symbol = min_asset_tokens[1];
+
+    uint8_t min_asset_precision = str_amount.size() - str_amount.find('.') - 1;
+    symbol min_asset_sym(
+       symbol_code(str_symbol), min_asset_precision 
+    );
+
+    str_amount.erase(
+        remove(str_amount.begin(), str_amount.end(), '.'),
+        str_amount.end()
+    );
+
+    asset min_asset;
+    min_asset.amount = stoi(str_amount);
+    min_asset.symbol = min_asset_sym;
+
+    // check both pools exist
+    auto fpool_it = sym_index.find(quantity.symbol.raw());
+    auto tpool_it = sym_index.find(min_asset.symbol.raw());
+    check(fpool_it != sym_index.end(), POOL_NOT_FOUND_ERR);
+    check(tpool_it != sym_index.end(), POOL_NOT_FOUND_ERR);
+
+    // check both pools have reserves
+    check(fpool_it->reserve.amount > 0, UNFUNDED_POOL_ERR);
+    check(tpool_it->reserve.amount > 0, UNFUNDED_POOL_ERR);
+
+    // validate recipient account & make transfer
+    name recipient = name(tokens[2]);
+    is_account(recipient);
+
+    // get current exchange rate
+    asset rate = asset_divide(fpool_it->reserve, tpool_it->reserve);
+
+    // get equivalent of quantity sent in target tokens
+    asset total = asset_multiply(quantity, rate);
+
+    check(total >= min_asset, BAD_DEAL_ERR);
+
+    action(
+        permission_level{get_self(), "active"_n},
+        tpool_it->token_contract,
+        "transfer"_n,
+        make_tuple(get_self(), from, total, "koinonos.v1 rate: " + rate.to_string())
+    ).send();
+
+    // update pool reserves
+    sym_index.modify(fpool_it, get_self(), [&](auto& row) {
+        row.reserve += quantity;
+    });
+    sym_index.modify(tpool_it, get_self(), [&](auto& row) {
+        row.reserve -= total;
+    });
+}

--- a/contracts/koinonospool/koinonospool.hpp
+++ b/contracts/koinonospool/koinonospool.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "errors.hpp"
+#include "utils.hpp"
+
+
+using std::string;
+
+using eosio::name;
+using eosio::asset;
+using eosio::symbol;
+using eosio::indexed_by;
+using eosio::multi_index;
+using eosio::const_mem_fun;
+
+static const char* PROTO_VERSION = "koinonos.v1";
+
+/*
+ *
+ * koinonospool protocol version 1
+ *
+ * transactions to this contract must use the following memo format
+ *
+ * "<version>,<min>,<recipient>"
+ *
+ * min: asset, minimum expected to convert, desired sym is extracted from here
+ * recipient: valid eosio name
+ *
+ */
+
+
+class [[eosio::contract("koinonospool")]] koinonospool : public eosio::contract {
+    public:
+        using contract::contract;
+
+        [[eosio::action]]
+        void initpool(
+            name admin,
+            name token_contract,
+            symbol token_sym
+        );
+
+        [[eosio::on_notify("*::transfer")]]
+        void transaction_handler(
+            name from,
+            name to,
+            asset quantity, string memo
+        );
+
+    private:
+        struct [[eosio::table]] poolinfo_s {
+            uint64_t id;
+            name     admin;
+            name     token_contract;
+            asset    reserve;
+
+            uint64_t primary_key() const { return id; }
+
+            uint64_t by_symbol() const { return reserve.symbol.raw(); }
+        };
+
+        typedef multi_index<"pools"_n, poolinfo_s,
+            indexed_by<"sym"_n, const_mem_fun<poolinfo_s, uint64_t, &poolinfo_s::by_symbol>>
+        > poolinfo_t;
+};
+

--- a/contracts/koinonospool/utils.hpp
+++ b/contracts/koinonospool/utils.hpp
@@ -1,0 +1,120 @@
+#pragma once
+
+#include <tuple>
+#include <string>
+#include <cstring>
+#include <algorithm>
+
+#include <eosio/asset.hpp>
+#include <eosio/eosio.hpp>
+#include <eosio/symbol.hpp>
+
+using std::string;
+using std::vector;
+using std::strlen;
+using std::strtok;
+using std::replace;
+
+using eosio::asset;
+
+
+inline int64_t ipow(int64_t base, uint64_t exp) {
+    if (exp == 0) return 1;
+
+    int64_t result = base;
+    for(int i = 0; i < (exp - 1); i++)
+        result *= base;
+
+    return result;
+}
+
+
+vector<string> split(const string &txt, const char * delim) {
+    vector<string> tokens;
+    string buffer(txt);
+    char* token = strtok(&buffer[0], delim);
+    while(token) {
+        tokens.push_back(string(token, token + strlen(token)));
+        token = strtok(NULL, delim);
+    }
+    return tokens;
+}
+
+int128_t divide(const asset &A, const asset &B) {
+    asset accurate, inaccurate;
+
+    if (A.symbol.precision() > B.symbol.precision()) {
+        accurate = A;
+        inaccurate = B;
+    } else {
+        accurate = B;
+        inaccurate = A;
+    }
+
+    // augment precision of most inaccurate amount
+    int dif = accurate.symbol.precision() - inaccurate.symbol.precision();
+
+    int128_t _accurate_amount = accurate.amount;
+    int128_t _fixed_amount = (int128_t)inaccurate.amount * ipow(10, dif);
+
+    // perform operation and add extra precision destroyed by operation
+    int128_t result = (
+        _fixed_amount * ipow(10, accurate.symbol.precision())
+    ) / _accurate_amount;
+
+    // if function should return amount using
+    // most accurate precision ret here
+
+    // if function should return using B asset precision 
+    dif = accurate.symbol.precision() - B.symbol.precision();
+
+    if (dif == 0) // B was the most accurate
+        return result;
+    else
+        return result / ipow(10, dif);
+        // dif > 0, B had less precision than A, remove extra precision
+
+}
+
+asset asset_divide(const asset &A, const asset &B) {
+    return asset(divide(A, B), B.symbol);
+}
+
+int128_t multiply(const asset &A, const asset &B) {
+    asset accurate, inaccurate;
+
+    if (A.symbol.precision() > B.symbol.precision()) {
+        accurate = A;
+        inaccurate = B;
+    } else {
+        accurate = B;
+        inaccurate = A;
+    }
+
+    // augment precision of most inaccurate amount
+    int dif = accurate.symbol.precision() - inaccurate.symbol.precision();
+
+    int128_t _accurate_amount = accurate.amount;
+    int128_t _fixed_amount = (int128_t)inaccurate.amount * ipow(10, dif);
+
+    // perform operation and remove extra precision created by operation
+    int128_t result = _fixed_amount * _accurate_amount;
+    result /= ipow(10, accurate.symbol.precision());
+
+    // if function should return amount using
+    // most accurate precision ret here
+
+    // if function should return using B asset precision 
+    dif = accurate.symbol.precision() - B.symbol.precision();
+
+    if (dif == 0) // B was the most accurate
+        return result;
+    else
+        return result / ipow(10, dif);
+        // dif > 0, B had less precision than A, remove extra precision
+
+}
+
+asset asset_multiply(const asset &A, const asset &B) {
+    return asset(multiply(A, B), B.symbol);
+}

--- a/contracts/manifest.toml
+++ b/contracts/manifest.toml
@@ -14,5 +14,8 @@ cdt = '1.6.3'
 [telosprofile]
 cdt = '1.7.0'
 
+[koinonospool]
+cdt = '1.7.0'
+
 [testcontract]
 cdt = '1.6.3'

--- a/tests/koinonospool/test_initpool.py
+++ b/tests/koinonospool/test_initpool.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+
+from pytest_eosiocdt import random_token_symbol
+
+
+def test_initpool(eosio_testnet):
+
+    poolname = 'koinonospool'
+
+    admin_accounts = [
+        eosio_testnet.new_account(), 
+        eosio_testnet.new_account()
+    ]
+    
+    # create tokens
+    symbols = [
+        random_token_symbol(),
+        random_token_symbol()
+    ]
+
+    # init pools
+    for admin, symbol in zip(admin_accounts, symbols):
+
+        proposal = eosio_testnet.multi_sig_propose(
+            admin,
+            [f'{poolname}@active', f'{admin}@active'],
+            [f'{poolname}@active', f'{admin}@active'],
+            poolname,
+            'initpool',
+            {
+                'admin': admin,
+                'token_contract': 'eosio.token',
+                'token_sym': f'2,{symbol}'
+            }
+        )
+
+        for approver in [poolname, admin]:
+            ec, _ = eosio_testnet.multi_sig_approve(
+                admin,
+                proposal,
+                [f'{approver}@active'],
+                approver
+            )
+            assert ec == 0
+
+        ec, _ = eosio_testnet.multi_sig_exec(
+            admin, proposal, admin)
+
+        search = [
+            pool 
+            for pool in eosio_testnet.get_table(
+                poolname,
+                poolname,
+                'pools'
+            )
+            if pool['admin'] == admin
+        ]
+
+        assert len(search) == 1
+        
+        pool = search[0]
+        assert pool['token_contract'] == 'eosio.token'
+        assert pool['reserve'] == f'0.00 {symbol}'
+
+    supplys = [
+        f'900000.00 {sym}' for sym in symbols
+    ]
+
+    pool_supp_amounts = [10000, 20000]
+
+    pool_supplys = [
+        f'{amount:.2f} {sym}'
+        for amount, sym in zip(pool_supp_amounts, symbols)
+    ]
+
+    for creator, symbol, max_supply, pool_supply in zip(
+        admin_accounts,
+        symbols,
+        supplys,
+        pool_supplys
+    ):
+        ec, _ = eosio_testnet.create_token(creator, max_supply)
+        assert ec == 0
+        ec, _ = eosio_testnet.issue_token(creator, pool_supply, '')
+        assert ec == 0
+    
+        # fund pool
+        ec, out = eosio_testnet.transfer_token(
+            creator,
+            poolname,
+            pool_supply,
+            'fund'
+        )
+        assert ec == 0
+        
+        search = [
+            pool 
+            for pool in eosio_testnet.get_table(
+                poolname,
+                poolname,
+                'pools'
+            )
+            if pool['admin'] == creator
+        ]
+
+        assert len(search) == 1
+        
+        pool = search[0]
+        assert pool['token_contract'] == 'eosio.token'
+        assert pool['reserve'] == pool_supply 
+
+
+    sender = eosio_testnet.new_account()
+    recipient = eosio_testnet.new_account()
+    
+    admin_a, admin_b = admin_accounts
+    sym_a, sym_b = symbols
+    
+    convert_amount = 100
+    convert_asset = f'{convert_amount:.2f} {sym_a}'
+    total_amount = 50
+    min_asset = f'{total_amount:.2f} {sym_b}'
+
+    ec, _ = eosio_testnet.issue_token(admin_a, convert_asset, '')
+    assert ec == 0
+    ec, _ = eosio_testnet.transfer_token(admin_a, sender, convert_asset, '')
+    assert ec == 0
+
+    # convert 100 tokens through to recipient
+    ec, _ = eosio_testnet.transfer_token(
+        sender,
+        poolname,
+        convert_asset,
+        f'koinonos.v1,{min_asset},{recipient}'
+    )
+
+    assert ec == 0
+   
+    pools = eosio_testnet.get_table(
+        poolname,
+        poolname,
+        'pools'
+    )
+
+    assert len(pools) == 2
+
+    pool_a, pool_b = pools
+    supply_a, supply_b = pool_supp_amounts
+
+    assert pool_a['reserve'] == f'{supply_a + convert_amount:.2f} {sym_a}'
+    assert pool_b['reserve'] == f'{supply_b - total_amount:.2f} {sym_b}'


### PR DESCRIPTION
Closes #46 

In the end I took the liberty to simplify the protocol.

To use the pool, after tokens are created & issued, one must call `koinonospool::initpool` which is a multi signature action (requires `get_self()` & the signature of the admin that creates the pool).

After that one must add funds to the pool, to do that, send a token transfer to the pool contract with nothing but the word `fund`.

To begin converting tokens we need a minimum of two funded pools.

### Converting tokens

Send a transfer to the pool contract using the following memo format:

    <protocol_string>,<minimum_asset>,<recipient>

Protocol string should always be `koinonos.v1` for now.