### PR TITLE
Update tests to latest plugin changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "contracts/telos.decide/libraries/telos.contracts"]
+	path = contracts/telos.decide/libraries/telos.contracts
+	url = https://github.com/telosnetwork/telos.contracts

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,7 +8,7 @@ To run tests:
 
 3 - Install the plugin:
 
-	pip install git+git://github.com/guilledk/pytest-eosiocdt.git
+	pip install git+git://github.com/guilledk/pytest-eosio.git
 
 4 - Run tests:
 

--- a/tests/telosbookdex/ballots/test_approvalmin.py
+++ b/tests/telosbookdex/ballots/test_approvalmin.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-from pytest_eosiocdt import name_to_string
-from pytest_eosiocdt.telos import telosdecide
+from pytest_eosio import name_to_string
+from pytest_eosio.telos import telosdecide
 
 from ..constants import telosbookdex
 

--- a/tests/telosbookdex/ballots/test_ballotsprune.py
+++ b/tests/telosbookdex/ballots/test_ballotsprune.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-from pytest_eosiocdt import name_to_string
-from pytest_eosiocdt.telos import telosdecide
+from pytest_eosio import name_to_string
+from pytest_eosio.telos import telosdecide
 
 from ..constants import telosbookdex
 

--- a/tests/telosbookdex/ballots/test_bantoken.py
+++ b/tests/telosbookdex/ballots/test_bantoken.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from pytest_eosiocdt.telos import telosdecide
+from pytest_eosio.telos import telosdecide
 
 from ..constants import telosbookdex
 

--- a/tests/telosbookdex/ballots/test_eventsprune.py
+++ b/tests/telosbookdex/ballots/test_eventsprune.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-from pytest_eosiocdt import name_to_string
-from pytest_eosiocdt.telos import telosdecide
+from pytest_eosio import name_to_string
+from pytest_eosio.telos import telosdecide
 
 from ..constants import telosbookdex
 

--- a/tests/telosbookdex/ballots/test_hblockprune.py
+++ b/tests/telosbookdex/ballots/test_hblockprune.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-from pytest_eosiocdt import name_to_string
-from pytest_eosiocdt.telos import telosdecide
+from pytest_eosio import name_to_string
+from pytest_eosio.telos import telosdecide
 
 from ..constants import telosbookdex
 

--- a/tests/telosbookdex/ballots/test_historyprune.py
+++ b/tests/telosbookdex/ballots/test_historyprune.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-from pytest_eosiocdt import name_to_string
-from pytest_eosiocdt.telos import telosdecide
+from pytest_eosio import name_to_string
+from pytest_eosio.telos import telosdecide
 
 from ..constants import telosbookdex
 

--- a/tests/telosbookdex/ballots/test_makerfee.py
+++ b/tests/telosbookdex/ballots/test_makerfee.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from pytest_eosiocdt.telos import telosdecide
+from pytest_eosio.telos import telosdecide
 
 from ..constants import telosbookdex
 

--- a/tests/telosbookdex/ballots/test_pointsprune.py
+++ b/tests/telosbookdex/ballots/test_pointsprune.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-from pytest_eosiocdt import name_to_string
-from pytest_eosiocdt.telos import telosdecide
+from pytest_eosio import name_to_string
+from pytest_eosio.telos import telosdecide
 
 from ..constants import telosbookdex
 

--- a/tests/telosbookdex/ballots/test_regcost.py
+++ b/tests/telosbookdex/ballots/test_regcost.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-from pytest_eosiocdt import name_to_string
-from pytest_eosiocdt.telos import telosdecide
+from pytest_eosio import name_to_string
+from pytest_eosio.telos import telosdecide
 
 from ..constants import telosbookdex
 

--- a/tests/telosbookdex/ballots/test_savetoken.py
+++ b/tests/telosbookdex/ballots/test_savetoken.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-from pytest_eosiocdt import name_to_string
-from pytest_eosiocdt.telos import telosdecide
+from pytest_eosio import name_to_string
+from pytest_eosio.telos import telosdecide
 
 from ..constants import telosbookdex
 

--- a/tests/telosbookdex/ballots/test_setcurrency.py
+++ b/tests/telosbookdex/ballots/test_setcurrency.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from pytest_eosiocdt.telos import telosdecide
+from pytest_eosio.telos import telosdecide
 
 from ..constants import telosbookdex
 

--- a/tests/telosbookdex/ballots/test_setreward.py
+++ b/tests/telosbookdex/ballots/test_setreward.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from pytest_eosiocdt.telos import telosdecide
+from pytest_eosio.telos import telosdecide
 
 from ..constants import telosbookdex
 

--- a/tests/telosbookdex/ballots/test_takerfee.py
+++ b/tests/telosbookdex/ballots/test_takerfee.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from pytest_eosiocdt.telos import telosdecide
+from pytest_eosio.telos import telosdecide
 
 from ..constants import telosbookdex
 

--- a/tests/telosbookdex/constants.py
+++ b/tests/telosbookdex/constants.py
@@ -10,7 +10,7 @@ from contextlib import contextmanager
 
 import pytest
 
-from pytest_eosiocdt import (
+from pytest_eosio import (
     collect_stdout,
     string_to_sym_code,
     name_to_string,
@@ -21,8 +21,8 @@ from pytest_eosiocdt import (
     Asset,
     Name
 )
-from pytest_eosiocdt.telos import init_telos_token, telos_token, vote_token
-from pytest_eosiocdt.contract import SmartContract
+from pytest_eosio.telos import init_telos_token, telos_token, vote_token
+from pytest_eosio.contract import SmartContract
 
 
 def get_market_index(

--- a/tests/telosbookdex/test_fake_deposit.py
+++ b/tests/telosbookdex/test_fake_deposit.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from pytest_eosiocdt import random_token_symbol
+from pytest_eosio import random_token_symbol
 
 from .constants import telosbookdex
 

--- a/tests/telosbookdex/test_history.py
+++ b/tests/telosbookdex/test_history.py
@@ -2,7 +2,7 @@
 
 from time import time
 
-from pytest_eosiocdt import (
+from pytest_eosio import (
     random_token_symbol,
     collect_stdout,
     name_to_string

--- a/tests/telosbookdex/test_market_ids.py
+++ b/tests/telosbookdex/test_market_ids.py
@@ -3,7 +3,7 @@
 import random
 import logging
 
-from pytest_eosiocdt import Asset, Symbol
+from pytest_eosio import Asset, Symbol
 
 from .constants import telosbookdex
 

--- a/tests/telosbookdex/test_math.py
+++ b/tests/telosbookdex/test_math.py
@@ -61,7 +61,7 @@ from decimal import Decimal, getcontext, ROUND_DOWN
 
 import pytest
 
-from pytest_eosiocdt import (
+from pytest_eosio import (
     collect_stdout,
     asset_from_decimal,
     asset_from_ints

--- a/tests/telosbookdex/test_order.py
+++ b/tests/telosbookdex/test_order.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from pytest_eosiocdt import random_token_symbol
+from pytest_eosio import random_token_symbol
 
 from .constants import telosbookdex
 

--- a/tests/telospooldex/constants.py
+++ b/tests/telospooldex/constants.py
@@ -4,13 +4,13 @@ from typing import List
 
 import pytest
 
-from pytest_eosiocdt import (
+from pytest_eosio import (
     Asset,
     Symbol,
     collect_stdout,
     asset_from_str
 )
-from pytest_eosiocdt.contract import SmartContract
+from pytest_eosio.contract import SmartContract
 
 
 class TelosPoolDEX(SmartContract):

--- a/tests/telospooldex/test_convert.py
+++ b/tests/telospooldex/test_convert.py
@@ -4,7 +4,7 @@ import copy
 import random
 import logging
 
-from pytest_eosiocdt import asset_from_str, Asset, Symbol
+from pytest_eosio import asset_from_str, Asset, Symbol
 
 from .constants import telospooldex
 from ..telosbookdex.constants import telosbookdex

--- a/tests/telospooldex/test_funding.py
+++ b/tests/telospooldex/test_funding.py
@@ -2,9 +2,9 @@
 
 import random
 
-from pytest_eosiocdt import Asset, Symbol, asset_from_str
-from pytest_eosiocdt.sugar import find_in_balances
-from pytest_eosiocdt.telos import telos_token
+from pytest_eosio import Asset, Symbol, asset_from_str
+from pytest_eosio.sugar import find_in_balances
+from pytest_eosio.telos import telos_token
 
 from .constants import telospooldex
 from ..telosbookdex.constants import telosbookdex

--- a/tests/telospooldex/test_participation.py
+++ b/tests/telospooldex/test_participation.py
@@ -4,7 +4,7 @@ import json
 import random
 import logging
 
-from pytest_eosiocdt import (
+from pytest_eosio import (
     Asset, Symbol, asset_from_str, find_in_balances)
 
 from .constants import telospooldex

--- a/tests/telosprofile/constants.py
+++ b/tests/telosprofile/constants.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 import pytest
 
-from pytest_eosiocdt import collect_stdout
+from pytest_eosio import collect_stdout
 
 
 class TelosProfile:

--- a/tests/telosprofile/test_chglink.py
+++ b/tests/telosprofile/test_chglink.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from pytest_eosiocdt import collect_stdout
+from pytest_eosio import collect_stdout
 
 from .constants import TelosProfile, telosprofile
 

--- a/tests/telosprofile/test_grantaccess.py
+++ b/tests/telosprofile/test_grantaccess.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from pytest_eosiocdt import collect_stdout
+from pytest_eosio import collect_stdout
 
 from .constants import TelosProfile, telosprofile
 

--- a/tests/telosprofile/test_witness.py
+++ b/tests/telosprofile/test_witness.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from pytest_eosiocdt import collect_stdout
+from pytest_eosio import collect_stdout
 
 from .constants import TelosProfile, telosprofile
 

--- a/tests/testcontract/test_utils.py
+++ b/tests/testcontract/test_utils.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from pytest_eosiocdt import (
+from pytest_eosio import (
     eosio_testnet,
     random_eosio_name,
     random_token_symbol,


### PR DESCRIPTION
This is a quick one, just changed the test plugin name from `pytest-eosiocdt` to `pytest-eosio` to be compiler agnostic.

Also add `telos.contracts` submodule that is needed for `telos.decide` compilation.